### PR TITLE
Add suggestValues for channel.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,25 @@
-# {{APP_NAME}} - Flows App
+# Flows Overview
 
-For general app development guidance, see @../CLAUDE.md
+Flows is a workflow automation tool targeted at DevOps engineers. You have blocks on a canvas connected by lines. Those blocks may have multiple inputs and outputs on which they send and receive events. We call these blocks "entities" as they can be very powerful. New entities can be implemented by means of apps which are implemented in JavaScript. Those entities can have http endpoints, manage infrastructure resources, have a lifecycle, and more. Entities live in flows.
+
+All configuration expressions and the code of apps are executed on agents, which are connected to the gateway via websockets. Those agents are responsible for managing Node.js runtimes for apps and for flows.
+
+This repository is an app repo based on our Flows App Template. It can be used as a starting point for building new Flows apps.
+
+When working on the app, **always** make sure to read the appRuntime.ts from https://docs.useflows.com/appRuntime.ts . This is later injected by the Flows runtime, you should never include it yourself. It's presented there as a reference.
+
+If necessary, you may also consider reading the documentation about building Flows apps at https://docs.useflows.com/developers/building-apps/ , specifically:
+- Configuration: https://docs.useflows.com/developers/building-apps/configuration/
+- Events: https://docs.useflows.com/developers/building-apps/events/
+- Lifecycle: https://docs.useflows.com/developers/building-apps/lifecycle/
+- KV Storage: https://docs.useflows.com/developers/building-apps/kv-storage/
+- HTTP Handlers: https://docs.useflows.com/developers/building-apps/http/
+- Scheduling: https://docs.useflows.com/developers/building-apps/scheduling/
+- Messaging: https://docs.useflows.com/developers/building-apps/messaging/
+
+If necessary, you can also find other apps in public repos of the https://github.com/spacelift-flows-apps organization.
 
 ## Overview
-
-{{APP_DESCRIPTION}}
 
 This app demonstrates the standard patterns for Flows apps:
 
@@ -103,6 +118,10 @@ const apiKey = input.app.config.apiKey as string;
 const baseUrl = input.app.config.baseUrl as string;
 ```
 
+### Schema
+
+- Make sure to properly mark required field as required in the schema (whether config field, or event output).
+
 ## Development Workflow
 
 ### Local Development
@@ -131,6 +150,95 @@ The template includes a complete CI/CD system:
 
 ## Best Practices
 
+### Configuration
+
+For commonly-static fields, try providing `suggestValues`. For example, in the Jira app we have
+```ts
+async function fetchIssueTypes(
+  jiraUrl: string,
+  email: string,
+  apiToken: string,
+  projectKey: string,
+): Promise<IssueType[]> {
+  const client = createJiraClient({ jiraUrl, email, apiToken });
+  const allTypes: IssueType[] = [];
+  let startAt = 0;
+  const maxResults = 50;
+
+  for (let page = 0; page < 10; page++) {
+    const response = await client.get<IssueTypePagedResponse>(
+      `/issue/createmeta/${projectKey}/issuetypes?startAt=${startAt}&maxResults=${maxResults}`,
+    );
+    if (!response.issueTypes || response.issueTypes.length === 0) break;
+    allTypes.push(...response.issueTypes);
+    if (startAt + response.issueTypes.length >= response.total) break;
+    startAt += response.issueTypes.length;
+  }
+
+  return allTypes;
+}
+
+const getIssueTypes = memoizee(fetchIssueTypes, {
+  maxAge: 60000,
+  promise: true,
+});
+
+// ...
+
+inputs: {
+  default: {
+    config: {
+      projectKey: {...},
+      issueTypeName: {
+        name: "Issue Type",
+          description: "The name of the issue type (e.g., 'Bug', 'Task', 'Story', 'Epic')",
+          type: "string",
+          required: true,
+          suggestValues: async (input) => {
+            const { jiraUrl, email, apiToken } = input.app.config;
+            const projectKey = input.staticInputConfig?.projectKey as
+              | string
+              | undefined;
+            
+            if (!projectKey) {
+              return {
+                suggestedValues: [],
+                message:
+                  "Configure static value for Project Key to receive suggestions.",
+              };
+            }
+            
+            const allTypes = await getIssueTypes(
+              jiraUrl as string,
+              email as string,
+              apiToken as string,
+              projectKey,
+            );
+            
+            let values = allTypes.map((type) => ({
+              label: type.name,
+              value: type.name,
+              description: type.description,
+            }));
+            
+            if (input.searchPhrase) {
+              const searchLower = input.searchPhrase.toLowerCase();
+              values = values.filter(
+                (v) =>
+                  v.label.toLowerCase().includes(searchLower) ||
+                  (v.description &&
+                    v.description.toLowerCase().includes(searchLower)),
+              );
+            }
+            
+            return { suggestedValues: values.slice(0, 50) };
+          },
+        },
+```
+The memoization helps avoid making a ton of api calls as the user is fine-tuning their search phrase.
+
+It's not worth it providing those for fields that are very dynamic, and the user will generally want to base on event data.
+
 ### Code Organization
 
 - Modular block structure in `blocks/` directory
@@ -146,7 +254,7 @@ The template includes a complete CI/CD system:
 
 ### Security
 
-- Use `secret: true` for sensitive configuration
+- Use `sensitive: true` for sensitive configuration
 - Never log sensitive data
 - Validate all inputs
 
@@ -185,6 +293,7 @@ export const blocks = {
 
 1. Update config schema in `main.ts`
 2. Access via `input.app.config.fieldName`
+3. For both app and block configs, make sure to use `default:` fields with `required: false`, when applicable, rather than using an optional field and conditionally providing a default value in app handlers.
 
 ### Adding Dependencies
 
@@ -193,3 +302,18 @@ export const blocks = {
 3. Ensure TypeScript types are available
 
 This template provides a solid foundation for building production-ready Flows apps with modern development practices and automated deployment.
+
+## Testing the App
+
+The app can be submitted to Flows as a custom app, or added to a registry.
+
+The user can use [flowctl](https://github.com/spacelift-io/flowctl) to create a custom app in their Flows organization, and then a version of the app inside of that. They will more or less have to run:
+```
+flowctl auth login # Follow the prompts to authenticate
+flowctl app create # Follow the prompts to create the app
+flowctl version update --entrypoint main.ts --watch # Follow the prompts to create a version in watch mode - this will update the app live as you make changes. Can skip --watch to just do a one-time upload.
+```
+
+More details can be found here:
+- https://docs.useflows.com/developers/deploying-apps/custom-apps/
+- https://docs.useflows.com/developers/deploying-apps/app-registries/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This repository is an app repo based on our Flows App Template. It can be used a
 When working on the app, **always** make sure to read the appRuntime.ts from https://docs.useflows.com/appRuntime.ts . This is later injected by the Flows runtime, you should never include it yourself. It's presented there as a reference.
 
 If necessary, you may also consider reading the documentation about building Flows apps at https://docs.useflows.com/developers/building-apps/ , specifically:
+
 - Configuration: https://docs.useflows.com/developers/building-apps/configuration/
 - Events: https://docs.useflows.com/developers/building-apps/events/
 - Lifecycle: https://docs.useflows.com/developers/building-apps/lifecycle/
@@ -153,6 +154,7 @@ The template includes a complete CI/CD system:
 ### Configuration
 
 For commonly-static fields, try providing `suggestValues`. For example, in the Jira app we have
+
 ```ts
 async function fetchIssueTypes(
   jiraUrl: string,
@@ -199,7 +201,7 @@ inputs: {
             const projectKey = input.staticInputConfig?.projectKey as
               | string
               | undefined;
-            
+
             if (!projectKey) {
               return {
                 suggestedValues: [],
@@ -207,20 +209,20 @@ inputs: {
                   "Configure static value for Project Key to receive suggestions.",
               };
             }
-            
+
             const allTypes = await getIssueTypes(
               jiraUrl as string,
               email as string,
               apiToken as string,
               projectKey,
             );
-            
+
             let values = allTypes.map((type) => ({
               label: type.name,
               value: type.name,
               description: type.description,
             }));
-            
+
             if (input.searchPhrase) {
               const searchLower = input.searchPhrase.toLowerCase();
               values = values.filter(
@@ -230,11 +232,12 @@ inputs: {
                     v.description.toLowerCase().includes(searchLower)),
               );
             }
-            
+
             return { suggestedValues: values.slice(0, 50) };
           },
         },
 ```
+
 The memoization helps avoid making a ton of api calls as the user is fine-tuning their search phrase.
 
 It's not worth it providing those for fields that are very dynamic, and the user will generally want to base on event data.
@@ -308,6 +311,7 @@ This template provides a solid foundation for building production-ready Flows ap
 The app can be submitted to Flows as a custom app, or added to a registry.
 
 The user can use [flowctl](https://github.com/spacelift-io/flowctl) to create a custom app in their Flows organization, and then a version of the app inside of that. They will more or less have to run:
+
 ```
 flowctl auth login # Follow the prompts to authenticate
 flowctl app create # Follow the prompts to create the app
@@ -315,5 +319,6 @@ flowctl version update --entrypoint main.ts --watch # Follow the prompts to crea
 ```
 
 More details can be found here:
+
 - https://docs.useflows.com/developers/deploying-apps/custom-apps/
 - https://docs.useflows.com/developers/deploying-apps/app-registries/

--- a/blocks/botThread.ts
+++ b/blocks/botThread.ts
@@ -1,6 +1,6 @@
 import { AppBlock, events, kv, EventInput } from "@slflows/sdk/v1";
 import { callSlackApi } from "../slackClient.ts";
-import { optionalChannelIdConfig } from "./utils/channelId.ts";
+import { optionalChannelOrUserIdConfig } from "./utils/channelId.ts";
 import { messagesSubscription } from "./subscriptions.ts";
 import sendMessageBlocks from "./sendMessageBlocks.ts";
 import { slackBlocksSchema } from "../jsonschema/jsonschema.ts";
@@ -15,7 +15,7 @@ export const botThread: AppBlock = {
 
   config: {
     channelId: {
-      ...optionalChannelIdConfig,
+      ...optionalChannelOrUserIdConfig,
       name: "Default Channel ID",
       description: "Default channel ID to use if not specified in inputs.",
     },
@@ -37,7 +37,7 @@ export const botThread: AppBlock = {
         "Start a new thread by posting the first message with Block Kit blocks.",
       config: {
         channelId: {
-          ...optionalChannelIdConfig,
+          ...optionalChannelOrUserIdConfig,
           description:
             "ID of the channel to post the message to. If not provided, uses the block's default channel.",
         },
@@ -63,7 +63,7 @@ export const botThread: AppBlock = {
       description: "Reply to an existing thread with Block Kit blocks.",
       config: {
         channelId: {
-          ...optionalChannelIdConfig,
+          ...optionalChannelOrUserIdConfig,
           description:
             "ID of the channel where the thread exists. If not provided, uses the block's default channel.",
         },

--- a/blocks/botThread.ts
+++ b/blocks/botThread.ts
@@ -1,5 +1,6 @@
 import { AppBlock, events, kv, EventInput } from "@slflows/sdk/v1";
 import { callSlackApi } from "../slackClient.ts";
+import { optionalChannelIdConfig } from "./utils/channelId.ts";
 import { messagesSubscription } from "./subscriptions.ts";
 import sendMessageBlocks from "./sendMessageBlocks.ts";
 import { slackBlocksSchema } from "../jsonschema/jsonschema.ts";
@@ -14,10 +15,9 @@ export const botThread: AppBlock = {
 
   config: {
     channelId: {
+      ...optionalChannelIdConfig,
       name: "Default Channel ID",
       description: "Default channel ID to use if not specified in inputs.",
-      type: "string",
-      required: false,
     },
     ttl: {
       name: "Thread TTL",
@@ -37,11 +37,9 @@ export const botThread: AppBlock = {
         "Start a new thread by posting the first message with Block Kit blocks.",
       config: {
         channelId: {
-          name: "Channel ID",
+          ...optionalChannelIdConfig,
           description:
             "ID of the channel to post the message to. If not provided, uses the block's default channel.",
-          type: "string",
-          required: false,
         },
         message: {
           name: "Message",
@@ -65,11 +63,9 @@ export const botThread: AppBlock = {
       description: "Reply to an existing thread with Block Kit blocks.",
       config: {
         channelId: {
-          name: "Channel ID",
+          ...optionalChannelIdConfig,
           description:
             "ID of the channel where the thread exists. If not provided, uses the block's default channel.",
-          type: "string",
-          required: false,
         },
         threadTs: {
           name: "Thread timestamp",

--- a/blocks/channels.ts
+++ b/blocks/channels.ts
@@ -6,6 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export const createChannel: AppBlock = {
   name: "Create Channel",
@@ -120,12 +121,7 @@ export const archiveChannel: AppBlock = {
       name: "Archive",
       description: "Trigger archiving the specified channel.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description: "ID of the channel (e.g., C0123ABC) to archive.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
       },
       async onEvent(input) {
         const { slackBotToken } = input.app.config;
@@ -178,12 +174,7 @@ export const unarchiveChannel: AppBlock = {
       name: "Unarchive",
       description: "Trigger unarchiving the specified channel.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description: "ID of the channel (e.g., C0123ABC) to unarchive.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
       },
       async onEvent(input) {
         const { slackBotToken } = input.app.config;
@@ -236,13 +227,7 @@ export const getChannelInfo: AppBlock = {
       name: "Get",
       description: "Trigger getting information about the specified channel.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) to get information about.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
       },
       async onEvent(input) {
         const { slackBotToken } = input.app.config;
@@ -376,13 +361,7 @@ export const setChannelTopic: AppBlock = {
       name: "Set",
       description: "Trigger setting the topic for the specified channel.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) to set the topic for.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         topic: {
           name: "Topic",
           description: "The new topic for the channel.",
@@ -447,13 +426,7 @@ export const setChannelPurpose: AppBlock = {
       name: "Set",
       description: "Trigger setting the purpose for the specified channel.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) to set the purpose for.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         purpose: {
           name: "Purpose",
           description: "The new purpose for the channel.",
@@ -519,12 +492,7 @@ export const inviteUsersToChannel: AppBlock = {
       name: "Invite",
       description: "Trigger inviting users to the specified channel.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description: "ID of the channel (e.g., C0123ABC) to invite users to.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         users: {
           name: "User IDs",
           description:
@@ -610,13 +578,7 @@ export const kickUsersFromChannel: AppBlock = {
       name: "Kick",
       description: "Trigger removing users from the specified channel.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) to remove users from.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         user: {
           name: "User ID",
           description: "User ID (e.g., U0123ABC) to remove from the channel.",

--- a/blocks/channels.ts
+++ b/blocks/channels.ts
@@ -6,7 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOnlyIdConfig } from "./utils/channelId.ts";
 
 export const createChannel: AppBlock = {
   name: "Create Channel",
@@ -121,7 +121,7 @@ export const archiveChannel: AppBlock = {
       name: "Archive",
       description: "Trigger archiving the specified channel.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
       },
       async onEvent(input) {
         const { slackBotToken } = input.app.config;
@@ -174,7 +174,7 @@ export const unarchiveChannel: AppBlock = {
       name: "Unarchive",
       description: "Trigger unarchiving the specified channel.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
       },
       async onEvent(input) {
         const { slackBotToken } = input.app.config;
@@ -227,7 +227,7 @@ export const getChannelInfo: AppBlock = {
       name: "Get",
       description: "Trigger getting information about the specified channel.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
       },
       async onEvent(input) {
         const { slackBotToken } = input.app.config;
@@ -361,7 +361,7 @@ export const setChannelTopic: AppBlock = {
       name: "Set",
       description: "Trigger setting the topic for the specified channel.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         topic: {
           name: "Topic",
           description: "The new topic for the channel.",
@@ -426,7 +426,7 @@ export const setChannelPurpose: AppBlock = {
       name: "Set",
       description: "Trigger setting the purpose for the specified channel.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         purpose: {
           name: "Purpose",
           description: "The new purpose for the channel.",
@@ -492,7 +492,7 @@ export const inviteUsersToChannel: AppBlock = {
       name: "Invite",
       description: "Trigger inviting users to the specified channel.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         users: {
           name: "User IDs",
           description:
@@ -578,7 +578,7 @@ export const kickUsersFromChannel: AppBlock = {
       name: "Kick",
       description: "Trigger removing users from the specified channel.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         user: {
           name: "User ID",
           description: "User ID (e.g., U0123ABC) to remove from the channel.",

--- a/blocks/conversation.ts
+++ b/blocks/conversation.ts
@@ -1,6 +1,6 @@
 import { AppBlock, events, kv, EventInput } from "@slflows/sdk/v1";
 import { callSlackApi } from "../slackClient.ts";
-import { optionalChannelOrUserIdConfig } from "./utils/channelId.ts";
+import { optionalChannelOnlyIdConfig } from "./utils/channelId.ts";
 import sendMessageBlocks from "./sendMessageBlocks.ts";
 import { messagesSubscription } from "./subscriptions.ts";
 
@@ -36,7 +36,7 @@ export const conversation: AppBlock = {
       required: false,
     },
     channelId: {
-      ...optionalChannelOrUserIdConfig,
+      ...optionalChannelOnlyIdConfig,
       description:
         "Restrict activity to this specific channel only. " +
         "If set, the bot will only respond to messages and mentions in this channel.",
@@ -65,10 +65,18 @@ export const conversation: AppBlock = {
       return;
     }
 
-    // If channel is configured, only process messages from that channel
+    // If channel is configured, only process messages from that channel.
+    // For DMs, also match the sender's user ID against the configured
+    // channel ID, since users configure a user ID (U...) but the event's
+    // channel is a DM channel ID (D...).
+    const configuredChannelId = block.config.channelId;
     if (
-      block.config.channelId &&
-      slackEvent.channel !== block.config.channelId
+      configuredChannelId &&
+      configuredChannelId !== slackEvent.channel &&
+      !(
+        slackEvent.channel_type === "im" &&
+        configuredChannelId === slackEvent.user
+      )
     ) {
       console.error(
         "Event unexpectedly received from a different channel: ",

--- a/blocks/conversation.ts
+++ b/blocks/conversation.ts
@@ -1,5 +1,6 @@
 import { AppBlock, events, kv, EventInput } from "@slflows/sdk/v1";
 import { callSlackApi } from "../slackClient.ts";
+import { optionalChannelIdConfig } from "./utils/channelId.ts";
 import sendMessageBlocks from "./sendMessageBlocks.ts";
 import { messagesSubscription } from "./subscriptions.ts";
 
@@ -35,12 +36,10 @@ export const conversation: AppBlock = {
       required: false,
     },
     channelId: {
-      name: "Channel ID",
+      ...optionalChannelIdConfig,
       description:
         "Restrict activity to this specific channel only. " +
         "If set, the bot will only respond to messages and mentions in this channel.",
-      type: "string",
-      required: false,
     },
   },
 

--- a/blocks/conversation.ts
+++ b/blocks/conversation.ts
@@ -1,6 +1,6 @@
 import { AppBlock, events, kv, EventInput } from "@slflows/sdk/v1";
 import { callSlackApi } from "../slackClient.ts";
-import { optionalChannelIdConfig } from "./utils/channelId.ts";
+import { optionalChannelOrUserIdConfig } from "./utils/channelId.ts";
 import sendMessageBlocks from "./sendMessageBlocks.ts";
 import { messagesSubscription } from "./subscriptions.ts";
 
@@ -36,7 +36,7 @@ export const conversation: AppBlock = {
       required: false,
     },
     channelId: {
-      ...optionalChannelIdConfig,
+      ...optionalChannelOrUserIdConfig,
       description:
         "Restrict activity to this specific channel only. " +
         "If set, the bot will only respond to messages and mentions in this channel.",

--- a/blocks/deleteMessage.ts
+++ b/blocks/deleteMessage.ts
@@ -6,7 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOnlyIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Delete Message",
@@ -18,7 +18,7 @@ export default {
       name: "Delete",
       description: "Trigger deletion of the specified message.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         ts: {
           name: "Message Timestamp",
           description: "The timestamp (ts) of the message to delete.",

--- a/blocks/deleteMessage.ts
+++ b/blocks/deleteMessage.ts
@@ -6,6 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Delete Message",
@@ -17,13 +18,7 @@ export default {
       name: "Delete",
       description: "Trigger deletion of the specified message.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) where the message is located.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         ts: {
           name: "Message Timestamp",
           description: "The timestamp (ts) of the message to delete.",

--- a/blocks/getThread.ts
+++ b/blocks/getThread.ts
@@ -1,6 +1,6 @@
 import { AppBlock, events } from "@slflows/sdk/v1";
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOnlyIdConfig } from "./utils/channelId.ts";
 import {
   slackChannelIdSchema,
   slackMessageTimestampSchema,
@@ -18,7 +18,7 @@ export const getThread: AppBlock = {
       description:
         "Retrieve the entire thread for the given message timestamp.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         threadTs: {
           name: "Thread Timestamp",
           description:

--- a/blocks/getThread.ts
+++ b/blocks/getThread.ts
@@ -1,5 +1,6 @@
 import { AppBlock, events } from "@slflows/sdk/v1";
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 import {
   slackChannelIdSchema,
   slackMessageTimestampSchema,
@@ -17,13 +18,7 @@ export const getThread: AppBlock = {
       description:
         "Retrieve the entire thread for the given message timestamp.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel where the thread exists (e.g., C0123ABC).",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         threadTs: {
           name: "Thread Timestamp",
           description:

--- a/blocks/reactions.ts
+++ b/blocks/reactions.ts
@@ -6,6 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export const getReactions: AppBlock = {
   name: "Get Reactions",
@@ -16,13 +17,7 @@ export const getReactions: AppBlock = {
       name: "Get",
       description: "Trigger getting reactions for the specified message.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) containing the message.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         ts: {
           name: "Message Timestamp",
           description:
@@ -147,13 +142,7 @@ export const addReaction: AppBlock = {
       name: "Add",
       description: "Trigger adding a reaction to the specified message.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) containing the message.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         ts: {
           name: "Message Timestamp",
           description:
@@ -226,13 +215,7 @@ export const removeReaction: AppBlock = {
       name: "Remove",
       description: "Trigger removing a reaction from the specified message.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) containing the message.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         ts: {
           name: "Message Timestamp",
           description:

--- a/blocks/reactions.ts
+++ b/blocks/reactions.ts
@@ -6,7 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOnlyIdConfig } from "./utils/channelId.ts";
 
 export const getReactions: AppBlock = {
   name: "Get Reactions",
@@ -17,7 +17,7 @@ export const getReactions: AppBlock = {
       name: "Get",
       description: "Trigger getting reactions for the specified message.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         ts: {
           name: "Message Timestamp",
           description:
@@ -142,7 +142,7 @@ export const addReaction: AppBlock = {
       name: "Add",
       description: "Trigger adding a reaction to the specified message.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         ts: {
           name: "Message Timestamp",
           description:
@@ -215,7 +215,7 @@ export const removeReaction: AppBlock = {
       name: "Remove",
       description: "Trigger removing a reaction from the specified message.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         ts: {
           name: "Message Timestamp",
           description:

--- a/blocks/sendEphemeralMessageBlocks.ts
+++ b/blocks/sendEphemeralMessageBlocks.ts
@@ -6,7 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOrUserIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Ephemeral Message Blocks",
@@ -18,7 +18,7 @@ export default {
       name: "Send",
       description: "Trigger sending the ephemeral message.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOrUserIdConfig,
         userId: {
           name: "User ID",
           description:

--- a/blocks/sendEphemeralMessageBlocks.ts
+++ b/blocks/sendEphemeralMessageBlocks.ts
@@ -6,6 +6,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Ephemeral Message Blocks",
@@ -17,13 +18,7 @@ export default {
       name: "Send",
       description: "Trigger sending the ephemeral message.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) to send the message to.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         userId: {
           name: "User ID",
           description:

--- a/blocks/sendMessageBlocks.ts
+++ b/blocks/sendMessageBlocks.ts
@@ -15,7 +15,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOrUserIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Message Blocks",
@@ -27,7 +27,7 @@ export default {
       name: "Send",
       description: "Trigger sending the message with blocks.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOrUserIdConfig,
         blocks: {
           name: "Message Blocks",
           description:

--- a/blocks/sendMessageBlocks.ts
+++ b/blocks/sendMessageBlocks.ts
@@ -15,6 +15,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Message Blocks",
@@ -26,13 +27,7 @@ export default {
       name: "Send",
       description: "Trigger sending the message with blocks.",
       config: {
-        channelId: {
-          name: "Channel or User ID",
-          description:
-            "ID of the channel (e.g., C0123ABC), DM (D0123ABC), or user (U0123ABC) to send the message to.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         blocks: {
           name: "Message Blocks",
           description:

--- a/blocks/sendMessageWithInteractions.ts
+++ b/blocks/sendMessageWithInteractions.ts
@@ -15,6 +15,7 @@ import {
 import { AppBlock, events, kv } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Message With Interactions",
@@ -26,13 +27,7 @@ export default {
       name: "Send",
       description: "Trigger sending the interactive message.",
       config: {
-        channelId: {
-          name: "Channel or User ID",
-          description:
-            "ID of the channel (e.g., C0123ABC), DM (D0123ABC), or user (U0123ABC) to send the message to.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         blocks: {
           name: "Message Blocks",
           description:

--- a/blocks/sendMessageWithInteractions.ts
+++ b/blocks/sendMessageWithInteractions.ts
@@ -15,7 +15,7 @@ import {
 import { AppBlock, events, kv } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOrUserIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Message With Interactions",
@@ -27,7 +27,7 @@ export default {
       name: "Send",
       description: "Trigger sending the interactive message.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOrUserIdConfig,
         blocks: {
           name: "Message Blocks",
           description:

--- a/blocks/sendTextMessage.ts
+++ b/blocks/sendTextMessage.ts
@@ -15,7 +15,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOrUserIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Text Message",
@@ -27,7 +27,7 @@ export default {
       name: "Send",
       description: "Trigger sending the message.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOrUserIdConfig,
         text: {
           name: "Message Text",
           description:

--- a/blocks/sendTextMessage.ts
+++ b/blocks/sendTextMessage.ts
@@ -15,6 +15,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Send Text Message",
@@ -26,13 +27,7 @@ export default {
       name: "Send",
       description: "Trigger sending the message.",
       config: {
-        channelId: {
-          name: "Channel or User ID",
-          description:
-            "ID of the channel (e.g., C0123ABC), DM (D0123ABC), or user (U0123ABC) to send the message to.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         text: {
           name: "Message Text",
           description:

--- a/blocks/subscriptions.ts
+++ b/blocks/subscriptions.ts
@@ -1,4 +1,5 @@
 import { AppBlock, blocks, events, messaging } from "@slflows/sdk/v1"; // TODO: Move the http subscription event handler here.
+import { optionalChannelIdConfig } from "./utils/channelId.ts";
 
 import {
   slackAppIdSchema,
@@ -66,10 +67,17 @@ export const handleEventSubscriptions = async (event: any) => {
       typeIds: ["messagesSubscription", "conversation", "botThread"],
     });
 
-    // Filter blocks by their configured channel (if present)
+    // Filter blocks by their configured channel (if present).
+    // For DMs (channel_type "im"), also match the sender's user ID against
+    // the configured channel ID, since users configure a user ID (U...) but
+    // the event's channel is a DM channel ID (D...).
     const relevantBlocks = messageSubscriptionBlocks.blocks.filter((block) => {
       const configuredChannelId = block.config.channelId;
-      return !configuredChannelId || configuredChannelId === event.channel;
+      return (
+        !configuredChannelId ||
+        configuredChannelId === event.channel ||
+        (event.channel_type === "im" && configuredChannelId === event.user)
+      );
     });
 
     if (relevantBlocks.length > 0) {
@@ -92,11 +100,9 @@ export const appMentionSubscription: AppBlock = {
   category: "Messaging",
   config: {
     channelId: {
-      name: "Channel ID (Optional)",
+      ...optionalChannelIdConfig,
       description:
         "If specified, only app mentions from this channel will be received. Leave empty to receive mentions from all channels the app has access to.",
-      type: "string",
-      required: false,
     },
   },
   async onInternalMessage({ block, message }) {
@@ -265,11 +271,9 @@ export const messagesSubscription: AppBlock = {
   category: "Messaging",
   config: {
     channelId: {
-      name: "Channel ID (Optional)",
+      ...optionalChannelIdConfig,
       description:
         "If specified, only messages from this channel will be received. Leave empty to receive messages from all channels the app has access to.",
-      type: "string",
-      required: false,
     },
     includeOwnMessages: {
       name: "Include Own Messages",
@@ -283,9 +287,19 @@ export const messagesSubscription: AppBlock = {
   async onInternalMessage({ app, block, message }) {
     const slackEvent = message.body;
     if (slackEvent && slackEvent.type === "message") {
-      // Check if we should filter by channel
+      // Check if we should filter by channel.
+      // For DMs, also match the sender's user ID against the configured
+      // channel ID, since users configure a user ID (U...) but the event's
+      // channel is a DM channel ID (D...).
       const configuredChannelId = block.config.channelId;
-      if (configuredChannelId && slackEvent.channel !== configuredChannelId) {
+      if (
+        configuredChannelId &&
+        configuredChannelId !== slackEvent.channel &&
+        !(
+          slackEvent.channel_type === "im" &&
+          configuredChannelId === slackEvent.user
+        )
+      ) {
         console.error(
           "Message unexpectedly received from a different channel: ",
           slackEvent.channel,

--- a/blocks/subscriptions.ts
+++ b/blocks/subscriptions.ts
@@ -1,5 +1,5 @@
 import { AppBlock, blocks, events, messaging } from "@slflows/sdk/v1"; // TODO: Move the http subscription event handler here.
-import { optionalChannelIdConfig } from "./utils/channelId.ts";
+import { optionalChannelOrUserIdConfig } from "./utils/channelId.ts";
 
 import {
   slackAppIdSchema,
@@ -100,7 +100,7 @@ export const appMentionSubscription: AppBlock = {
   category: "Messaging",
   config: {
     channelId: {
-      ...optionalChannelIdConfig,
+      ...optionalChannelOrUserIdConfig,
       description:
         "If specified, only app mentions from this channel will be received. Leave empty to receive mentions from all channels the app has access to.",
     },
@@ -271,7 +271,7 @@ export const messagesSubscription: AppBlock = {
   category: "Messaging",
   config: {
     channelId: {
-      ...optionalChannelIdConfig,
+      ...optionalChannelOrUserIdConfig,
       description:
         "If specified, only messages from this channel will be received. Leave empty to receive messages from all channels the app has access to.",
     },

--- a/blocks/updateMessageBlocks.ts
+++ b/blocks/updateMessageBlocks.ts
@@ -7,7 +7,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
-import { channelIdConfig } from "./utils/channelId.ts";
+import { channelOnlyIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Update Message Blocks",
@@ -18,7 +18,7 @@ export default {
       name: "Update",
       description: "Trigger updating the message with new blocks.",
       config: {
-        channelId: channelIdConfig,
+        channelId: channelOnlyIdConfig,
         ts: {
           name: "Message Timestamp",
           description: "Timestamp (ts) of the message to update.",

--- a/blocks/updateMessageBlocks.ts
+++ b/blocks/updateMessageBlocks.ts
@@ -7,6 +7,7 @@ import {
 import { AppBlock, events } from "@slflows/sdk/v1";
 
 import { callSlackApi } from "../slackClient.ts";
+import { channelIdConfig } from "./utils/channelId.ts";
 
 export default {
   name: "Update Message Blocks",
@@ -17,13 +18,7 @@ export default {
       name: "Update",
       description: "Trigger updating the message with new blocks.",
       config: {
-        channelId: {
-          name: "Channel ID",
-          description:
-            "ID of the channel (e.g., C0123ABC) containing the message to update.",
-          type: "string",
-          required: true,
-        },
+        channelId: channelIdConfig,
         ts: {
           name: "Message Timestamp",
           description: "Timestamp (ts) of the message to update.",

--- a/blocks/utils/channelId.ts
+++ b/blocks/utils/channelId.ts
@@ -17,7 +17,7 @@ async function fetchChannels(slackBotToken: string): Promise<Channel[]> {
   const allChannels: Channel[] = [];
   let cursor: string | undefined;
 
-  do {
+  for (let page = 0; page < 10; page++) {
     const payload: Record<string, any> = {
       types: "public_channel,private_channel",
       exclude_archived: true,
@@ -44,7 +44,8 @@ async function fetchChannels(slackBotToken: string): Promise<Channel[]> {
     }
 
     cursor = responseData.response_metadata?.next_cursor;
-  } while (cursor);
+    if (!cursor) break;
+  }
 
   return allChannels;
 }
@@ -53,7 +54,7 @@ async function fetchUsers(slackBotToken: string): Promise<User[]> {
   const allUsers: User[] = [];
   let cursor: string | undefined;
 
-  do {
+  for (let page = 0; page < 10; page++) {
     const payload: Record<string, any> = {
       limit: 1000,
     };
@@ -79,7 +80,8 @@ async function fetchUsers(slackBotToken: string): Promise<User[]> {
     }
 
     cursor = responseData.response_metadata?.next_cursor;
-  } while (cursor);
+    if (!cursor) break;
+  }
 
   return allUsers;
 }
@@ -93,6 +95,37 @@ const getUsers = memoizee(fetchUsers, {
   maxAge: 60000,
   promise: true,
 });
+
+async function suggestChannelOnly(input: any) {
+  const slackBotToken = input.app.config.slackBotToken as string | undefined;
+
+  if (!slackBotToken) {
+    return {
+      suggestedValues: [],
+      message: "Configure the Slack Bot Token to receive channel suggestions.",
+    };
+  }
+
+  const channels = await getChannels(slackBotToken);
+
+  let values = channels.map((channel) => ({
+    label: channel.is_private
+      ? `${channel.name} (private)`
+      : `#${channel.name}`,
+    value: channel.id,
+  }));
+
+  if (input.searchPhrase) {
+    const searchLower = input.searchPhrase.toLowerCase();
+    values = values.filter(
+      (v) =>
+        v.label.toLowerCase().includes(searchLower) ||
+        v.value.toLowerCase().includes(searchLower),
+    );
+  }
+
+  return { suggestedValues: values.slice(0, 50) };
+}
 
 async function suggestChannelId(input: any) {
   const slackBotToken = input.app.config.slackBotToken as string | undefined;
@@ -134,8 +167,16 @@ async function suggestChannelId(input: any) {
   return { suggestedValues: values.slice(0, 50) };
 }
 
-export const channelIdConfig = {
+export const channelOnlyIdConfig = {
   name: "Channel ID",
+  description: "ID of the channel (e.g., C0123ABC).",
+  type: "string" as const,
+  required: true as const,
+  suggestValues: suggestChannelOnly,
+};
+
+export const channelOrUserIdConfig = {
+  name: "Channel or User ID",
   description:
     "ID of the channel (e.g., C0123ABC), DM (D0123ABC), or user (U0123ABC).",
   type: "string" as const,
@@ -143,8 +184,8 @@ export const channelIdConfig = {
   suggestValues: suggestChannelId,
 };
 
-export const optionalChannelIdConfig = {
-  name: "Channel ID",
+export const optionalChannelOrUserIdConfig = {
+  name: "Channel or User ID",
   description:
     "ID of the channel (e.g., C0123ABC), DM (D0123ABC), or user (U0123ABC).",
   type: "string" as const,

--- a/blocks/utils/channelId.ts
+++ b/blocks/utils/channelId.ts
@@ -175,6 +175,14 @@ export const channelOnlyIdConfig = {
   suggestValues: suggestChannelOnly,
 };
 
+export const optionalChannelOnlyIdConfig = {
+  name: "Channel ID",
+  description: "ID of the channel (e.g., C0123ABC).",
+  type: "string" as const,
+  required: false as const,
+  suggestValues: suggestChannelOnly,
+};
+
 export const channelOrUserIdConfig = {
   name: "Channel or User ID",
   description:

--- a/blocks/utils/channelId.ts
+++ b/blocks/utils/channelId.ts
@@ -1,0 +1,153 @@
+import memoizee from "memoizee";
+import { callSlackApi } from "../../slackClient.ts";
+
+interface Channel {
+  id: string;
+  name: string;
+  is_private: boolean;
+}
+
+interface User {
+  id: string;
+  name: string;
+  real_name: string;
+}
+
+async function fetchChannels(slackBotToken: string): Promise<Channel[]> {
+  const allChannels: Channel[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const payload: Record<string, any> = {
+      types: "public_channel,private_channel",
+      exclude_archived: true,
+      limit: 1000,
+    };
+
+    if (cursor) {
+      payload.cursor = cursor;
+    }
+
+    const responseData = await callSlackApi(
+      "conversations.list",
+      payload,
+      slackBotToken,
+      "form",
+    );
+
+    for (const channel of responseData.channels) {
+      allChannels.push({
+        id: channel.id,
+        name: channel.name,
+        is_private: channel.is_private,
+      });
+    }
+
+    cursor = responseData.response_metadata?.next_cursor;
+  } while (cursor);
+
+  return allChannels;
+}
+
+async function fetchUsers(slackBotToken: string): Promise<User[]> {
+  const allUsers: User[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const payload: Record<string, any> = {
+      limit: 1000,
+    };
+
+    if (cursor) {
+      payload.cursor = cursor;
+    }
+
+    const responseData = await callSlackApi(
+      "users.list",
+      payload,
+      slackBotToken,
+      "form",
+    );
+
+    for (const user of responseData.members) {
+      if (user.deleted || user.is_bot || user.id === "USLACKBOT") continue;
+      allUsers.push({
+        id: user.id,
+        name: user.name,
+        real_name: user.real_name || user.name,
+      });
+    }
+
+    cursor = responseData.response_metadata?.next_cursor;
+  } while (cursor);
+
+  return allUsers;
+}
+
+const getChannels = memoizee(fetchChannels, {
+  maxAge: 60000,
+  promise: true,
+});
+
+const getUsers = memoizee(fetchUsers, {
+  maxAge: 60000,
+  promise: true,
+});
+
+async function suggestChannelId(input: any) {
+  const slackBotToken = input.app.config.slackBotToken as string | undefined;
+
+  if (!slackBotToken) {
+    return {
+      suggestedValues: [],
+      message: "Configure the Slack Bot Token to receive channel suggestions.",
+    };
+  }
+
+  const [channels, users] = await Promise.all([
+    getChannels(slackBotToken),
+    getUsers(slackBotToken),
+  ]);
+
+  let values = [
+    ...channels.map((channel) => ({
+      label: channel.is_private
+        ? `${channel.name} (private)`
+        : `#${channel.name}`,
+      value: channel.id,
+    })),
+    ...users.map((user) => ({
+      label: user.real_name,
+      value: user.id,
+    })),
+  ];
+
+  if (input.searchPhrase) {
+    const searchLower = input.searchPhrase.toLowerCase();
+    values = values.filter(
+      (v) =>
+        v.label.toLowerCase().includes(searchLower) ||
+        v.value.toLowerCase().includes(searchLower),
+    );
+  }
+
+  return { suggestedValues: values.slice(0, 50) };
+}
+
+export const channelIdConfig = {
+  name: "Channel ID",
+  description:
+    "ID of the channel (e.g., C0123ABC), DM (D0123ABC), or user (U0123ABC).",
+  type: "string" as const,
+  required: true as const,
+  suggestValues: suggestChannelId,
+};
+
+export const optionalChannelIdConfig = {
+  name: "Channel ID",
+  description:
+    "ID of the channel (e.g., C0123ABC), DM (D0123ABC), or user (U0123ABC).",
+  type: "string" as const,
+  required: false as const,
+  suggestValues: suggestChannelId,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
       "dependencies": {
         "@slflows/sdk": "^0.7.0",
         "@types/node": "^22.15.28",
+        "memoizee": "^0.4.17",
         "typescript": "^5.8.3"
       },
       "devDependencies": {
+        "@types/memoizee": "^0.4.12",
         "@types/node": "^24.0.7",
         "@useflows/flowctl": "^0.1.1",
         "prettier": "^3.6.2",
@@ -568,13 +570,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/memoizee": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
+      "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
       "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -694,6 +702,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/default-browser": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
@@ -747,6 +768,58 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
@@ -789,6 +862,40 @@
         "@esbuild/win32-x64": "0.25.8"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -824,6 +931,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -840,12 +953,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/minipass": {
       "version": "7.1.2",
@@ -885,6 +1026,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/open": {
       "version": "10.2.0",
@@ -989,6 +1136,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -1033,12 +1193,17 @@
         }
       }
     },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "type": "module",
   "dependencies": {
     "@slflows/sdk": "^0.7.0",
-    "typescript": "^5.8.3",
-    "@types/node": "^22.15.28"
+    "@types/node": "^22.15.28",
+    "memoizee": "^0.4.17",
+    "typescript": "^5.8.3"
   },
   "devDependencies": {
+    "@types/memoizee": "^0.4.12",
     "@types/node": "^24.0.7",
     "@useflows/flowctl": "^0.1.1",
     "prettier": "^3.6.2",


### PR DESCRIPTION
Also adjusts the message listening logic to allow listening to a specific user via dm.

I tried to properly assign the logic of which blocks work with channels/users, and which with only channels. The general logic seems to be more or less:
- if it's sending a new messages, either channel or user works
- if it's doing anything else inside of a channel (e.g. adding a reaction to a message), only channel id works

interestingly, responding to a thread allows a user id.